### PR TITLE
Update DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -42,7 +42,7 @@
  + Ruby
    - [TelegramBot](https://github.com/eljojo/telegram_bot)
  + Go
-   - [TBotAPI](https://github.com/mrd0ll4r/tbotapi)
+   - [tgbotapi](https://github.com/go-telegram-bot-api/telegram-bot-api)
  + Lua
    - [lua-telegram-bot](https://github.com/cosmonawt/lua-telegram-bot)
  + Haskell


### PR DESCRIPTION
Библиотека для Go [TBotAPI](https://github.com/mrd0ll4r/tbotapi) заменена на [tgbotapi](https://github.com/go-telegram-bot-api/telegram-bot-api), т.к. предыдущая перестала поддерживаться.